### PR TITLE
dep: Update bindgen

### DIFF
--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 links = "mbedcrypto"
 
 [build-dependencies]
-bindgen = { version = "0.59.2", optional = true }
+bindgen = { version = "^0.69", optional = true }
 cc = "1.0.59"
 cmake = "0.1.44"
 walkdir = "2.3.1"


### PR DESCRIPTION
This fixes errors on newer systems (possibly LLVM 16) such as:

```
thread 'main' panicked at '"enum_(unnamed_at_/home/chrysn/_cache/cargo-target/debug/build/psa-crypto-sys-f1543d213eb456fc/out/include/mbedtls/cipher_h_205_1)" is not a valid Ident'
```

Unblocks: https://github.com/openwsn-berkeley/lakers/pull/292 (and lakers building on nightly in general)